### PR TITLE
1 amulets still behaving like normal nether stars

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,20 @@ Note: Do not make any changes to the `quests.json` file.
 
 ## Known issues
 
-- Amulets also behaving like normal nether stars ([Issue #1](https://github.com/jbowenfavre4/AmuletQuest/issues/1))
-- Essence also behaving like normal glowstone dust ([Issue #2](https://github.com/jbowenfavre4/AmuletQuest/issues/2))
+- ~~Amulets also behaving like normal nether stars~~ ([Issue #1 (Fixed in 1.0.1)](https://github.com/jbowenfavre4/AmuletQuest/issues/1))
+- ~~Essence also behaving like normal glowstone dust~~ ([Issue #2 (Fixed in 1.0.1)](https://github.com/jbowenfavre4/AmuletQuest/issues/2))
 
 ## Future updates
 
 - Combining amulets
 
 ## Version History
+
+### [v1.0.1](https://github.com/jbowenfavre4/AmuletQuest/releases/tag/v1.0.1)
+- Release Date: TBD
+- Bug fixes:
+  - fixed amulets and essence behaving like normal nether stars and glowstone dust in crafting
+
 ### [v1.0.0](https://github.com/jbowenfavre4/AmuletQuest/releases/tag/v1.0.0)
 - Release Date: 2023-11-20
 - Initial Release

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.diz</groupId>
     <artifactId>AmuletQuest</artifactId>
-    <version>1.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>AmuletQuest</name>

--- a/src/main/java/com/diz/AmuletQuest/Main.java
+++ b/src/main/java/com/diz/AmuletQuest/Main.java
@@ -55,6 +55,7 @@ public final class Main extends JavaPlugin {
             Bukkit.getPluginManager().registerEvents(new PlayerFishListener(), this);
             Bukkit.getPluginManager().registerEvents(new PlayerFindEntityListener(), this);
             Bukkit.getPluginManager().registerEvents(new CraftingInteractListener(), this);
+            Bukkit.getPluginManager().registerEvents(new CraftingCancelListener(), this);
 
             FileManager.getInstance(this);
 

--- a/src/main/java/com/diz/AmuletQuest/eventlisteners/CraftingCancelListener.java
+++ b/src/main/java/com/diz/AmuletQuest/eventlisteners/CraftingCancelListener.java
@@ -1,0 +1,36 @@
+package com.diz.AmuletQuest.eventlisteners;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class CraftingCancelListener implements Listener {
+
+    @EventHandler
+    public void onCraftItem(PrepareItemCraftEvent e) {
+        if (e.getRecipe() != null) {
+            if (checkForItem(e.getInventory().getMatrix(), "Amulet", Material.NETHER_STAR)) {
+                e.getInventory().setResult(new ItemStack(Material.AIR));
+            }
+
+            if (checkForItem(e.getInventory().getMatrix(), "essence", Material.GLOWSTONE_DUST)) {
+                e.getInventory().setResult(new ItemStack(Material.AIR));
+            }
+
+        }
+    }
+
+    public static Boolean checkForItem(ItemStack[] itemList, String identifier, Material material) {
+        for (ItemStack itemStack : itemList) {
+            if (itemStack != null && itemStack.getType() == material) {
+                if (itemStack.getItemMeta().getDisplayName().contains(identifier)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/diz/AmuletQuest/eventlisteners/EntityDeathListener.java
+++ b/src/main/java/com/diz/AmuletQuest/eventlisteners/EntityDeathListener.java
@@ -26,8 +26,6 @@ import java.util.*;
 // listens for mob deaths and handles dropping the quest book
 public class EntityDeathListener implements Listener {
 
-    private Integer defaultDropChance = 10;
-
     private JavaPlugin plugin;
 
     public EntityDeathListener(JavaPlugin plugin) {

--- a/src/main/java/com/diz/AmuletQuest/singeltons/ConfigManager.java
+++ b/src/main/java/com/diz/AmuletQuest/singeltons/ConfigManager.java
@@ -1,16 +1,9 @@
 package com.diz.AmuletQuest.singeltons;
-import com.diz.AmuletQuest.Main;
-import com.diz.AmuletQuest.eventlisteners.CraftingInteractListener;
-import com.diz.AmuletQuest.eventlisteners.EntityDeathListener;
-import com.diz.AmuletQuest.eventlisteners.PlayerFindEntityListener;
-import com.diz.AmuletQuest.eventlisteners.PlayerFishListener;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * Singleton class responsible for creating config file if needed and saving the values on startup.

--- a/src/main/java/com/diz/AmuletQuest/staticClasses/QuestGiver.java
+++ b/src/main/java/com/diz/AmuletQuest/staticClasses/QuestGiver.java
@@ -7,16 +7,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.UUID;
 
 public class QuestGiver {
 

--- a/src/main/java/com/diz/AmuletQuest/staticClasses/Utilities.java
+++ b/src/main/java/com/diz/AmuletQuest/staticClasses/Utilities.java
@@ -1,6 +1,9 @@
 package com.diz.AmuletQuest.staticClasses;
 
+import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Random;

--- a/src/main/java/com/diz/AmuletQuest/staticClasses/Utilities.java
+++ b/src/main/java/com/diz/AmuletQuest/staticClasses/Utilities.java
@@ -1,9 +1,6 @@
 package com.diz.AmuletQuest.staticClasses;
 
-import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Random;


### PR DESCRIPTION
Fixes issues 1 and 2, where amulets and essence were behaving like normal nether stars and glowstone dust. The player should not be able to craft a beacon using an amulet in place or a nether star, for example. This change now listens for an item to be crafted and cancels the result if the crafting matrix contains either an amulet or essence. 

This should not be merged until testing is finished and the changes are ready to be released. 